### PR TITLE
fix: special characters in Telegram messages

### DIFF
--- a/notify-via-telegram.ts
+++ b/notify-via-telegram.ts
@@ -13,7 +13,7 @@ export async function notifyViaTelegram() {
     
     const messageToBeSent = `https://github.com/${repo}: ${message}`
 
-    const url = `https://api.telegram.org/bot${telegramBotToken}/sendMessage?chat_id=${telegramTargetChatId}&text=${messageToBeSent}&disable_web_page_preview=true`
+    const url = `https://api.telegram.org/bot${telegramBotToken}/sendMessage?chat_id=${telegramTargetChatId}&text=${encodeURIComponent(messageToBeSent)}&disable_web_page_preview=true`
     
     await Request.get(url)
 }


### PR DESCRIPTION
Special characters, such as newlines, # sign, & sign and more don't work in telegram messages, due to not being escaped in the api request url
encodeURIComponent escapes those characters properly using percent-encoding